### PR TITLE
perf(calculator): use linear scan with primality check to compute goldbach factors

### DIFF
--- a/client/src/components/contact.js
+++ b/client/src/components/contact.js
@@ -5,8 +5,19 @@ class Contact extends Component {
     return (
       <div>
         <div className="section-header">Contact</div>
-        <div>email: ispashayev@gmail.com</div>
-        <div>github: ispashayev</div>
+        <div>
+          email: ispashayev@gmail.com
+        </div>
+        <div>
+          github:&nbsp;
+          <a
+            href="https://github.com/ispashayev"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            ispashayev
+          </a>
+        </div>
       </div>
     );
   }

--- a/client/src/components/discussion.js
+++ b/client/src/components/discussion.js
@@ -33,14 +33,15 @@ const Discussion = () =>
     </div>
     <br />
     <div>
-      Note about the Goldbach Factorizer above:
+      Details about the Goldbach Factorizer implementation:
       <br /><br />
-      The way it works is by searching through a large primes file (10,000,000 primes).
-      Many even numbers have a very small prime number as one of their prime factors,
-      which is why in the common case the server performs the factorization
-      quickly. However, at some point the search takes a few minutes to compute since
-      the largest prime in the file is under 16,000,000. For example, factoring
-      30,000,000 will still work, but take 5-10 minutes.
+      The way it works is by scanning through a large primes file (10,000,000 primes)
+      for the first prime number. It then checks if the difference between that prime
+      and the queried even number is prime. Many even numbers have a very small prime
+      number as one of their prime factors, which is why in the common case the server
+      performs the factorization quickly. Where this method would fail is a large even
+      number where the Goldbach Factors are close to each other. Determining what even
+      numbers fit this criteria could be an interesting question.
       <br /><br />
       The prime number file was generated using a Fortran program that implements
       the sieve of Eratosthenes. The upper bound for generating 10,000,000 primes

--- a/client/src/components/goldbach-calculator.js
+++ b/client/src/components/goldbach-calculator.js
@@ -49,10 +49,6 @@ class GoldbachCalculator extends Component {
           queries: updatedQueries,
         });
       }
-
-      this.setState({
-        n: undefined,
-      });
     });
   }
 
@@ -61,8 +57,7 @@ class GoldbachCalculator extends Component {
       <div>
         <div className="section-header">The Goldbach Conjecture</div>
         <div>
-          Any even number can be expressed as the sum of two primes. We define this
-          pair of primes as the <b>Goldbach Factors</b>. Test it out yourself!
+          Any even number can be expressed as the sum of two primes. Test it out yourself!
         </div>
         <br />
         <div>


### PR DESCRIPTION
# What

This PR updates the goldbach factorization to avoid the O(n^2) search for primes. Instead, the search now performs a linear scan of the primes, and computes the difference between the prime and the queried even number. If the difference is prime, then we are done. This new method vastly increases the upper bound for goldbach factorization.

This PR also fixes a bug where submitting a query would internally clear out the query value.