### PR TITLE
refactor(client): use built-in react fetch to make API requests

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "axios": "^0.18.0",
     "react": "^16.4.1",
     "react-bootstrap": "^1.0.0-beta.8",
     "react-dom": "^16.4.1",

--- a/client/src/components/goldbach-calculator.js
+++ b/client/src/components/goldbach-calculator.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import axios from 'axios';
 
 import Button from 'react-bootstrap/Button';
 import Card from 'react-bootstrap/Card';
@@ -33,14 +32,14 @@ class GoldbachCalculator extends Component {
       return;
     }
 
-    axios
-    .get(`/factor/${this.state.n}`)
+    fetch(`/factor/${this.state.n}`)
+    .then(res => res.json())
     .then(res => {
-      if (res.data.success === true) {
+      if (res.success) {
         const queryResult = {
           n: this.state.n,
-          p: res.data.primeOne,
-          q: res.data.primeTwo,
+          p: res.primeOne,
+          q: res.primeTwo,
         };
         let updatedQueries = this.state.queries.slice();
         updatedQueries.push(queryResult);


### PR DESCRIPTION
# What

This PR updates the frontend to use the standard `fetch` function that comes with React to make an API request for the goldbach query, rather than the axios library. This is due to simplicity, and also because dependabot was flagging a security vulnerability for the version of axios that was being used.